### PR TITLE
Fix signing for non-evk boards

### DIFF
--- a/meta-secure-boot/recipes-secure-boot/imx-mkimage/imx-boot_%.bbappend
+++ b/meta-secure-boot/recipes-secure-boot/imx-mkimage/imx-boot_%.bbappend
@@ -15,7 +15,7 @@ do_compile:append:ahab() {
     mv ${BOOT_STAGING}/flash.bin ${BOOT_STAGING}/flash.bak
 
     # Invoke mkimage again to Get container info
-    make SOC=${IMX_BOOT_SOC_TARGET} flash_kernel
+    make SOC=${IMX_BOOT_SOC_TARGET} ${MKIMAGE_EXTRA_ARGS} flash_kernel
 
     # Rename kernel image name and move back the imx-boot flash image name
     mv ${BOOT_STAGING}/flash.bin ${BOOT_STAGING}/flash_os.bin


### PR DESCRIPTION
imx-boot/iMX93/soc.mak defines KERNEL_DTB by default as: imx93-11x11-evk.dtb

```
imx-boot/1.0/git$ grep KERNEL_DTB iMX93/soc.mak
  KERNEL_DTB ?= imx93-11x11-evk.dtb   # Used by kernel authentication
  KERNEL_DTB_ADDR ?= 0x83000000
  flash_kernel: $(MKIMG) Image $(KERNEL_DTB)
          ./$(MKIMG) -soc IMX9 -c -ap Image a55 $(KERNEL_ADDR) --data $(KERNEL_DTB) a55 $(KERNEL_DTB_ADDR) -out flash.bin
```

When building for another board, it complains with:
`  make[1]: *** No rule to make target 'imx93-11x11-evk.dtb', needed by 'flash_kernel'.  Stop.`

In the base imx-boot_1.0.bb, calls for make targets are done with ${MKIMAGE_EXTRA_ARGS}. Adding the option to imx-boot_%.bbappend allows passing non default dtb to mkimage.