### PR TITLE
Create imx-boot-tools directory if not present

### DIFF
--- a/meta-secure-boot/recipes-secure-boot/u-boot/u-boot-imx_%.bbappend
+++ b/meta-secure-boot/recipes-secure-boot/u-boot/u-boot-imx_%.bbappend
@@ -21,6 +21,7 @@ do_compile:prepend:ahab() {
 }
 
 BOOT_TOOLS = "imx-boot-tools"
+do_deploy[dirs]:hab4 += "${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}"
 
 do_deploy:append:hab4() {
     unset i j


### PR DESCRIPTION
u-boot recipe does install the uboot config file inside ***${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}*** for the kernel to get the **CONFIG_SYS_LOAD_ADDR** for signing, but there is a possibility that the folder is not created during the u-boot build. So it's good to create the ***${DEPLOY_DIR_IMAGE}/${BOOT_TOOLS}*** directory before installing the uboot config file to the directory.